### PR TITLE
str.replace() will error if field['value'] is not a str type

### DIFF
--- a/djangocms_forms/forms.py
+++ b/djangocms_forms/forms.py
@@ -356,10 +356,10 @@ class FormBuilder(forms.Form):
         for field in form_data:
             if mail_reply_to:
                 mail_reply_to = mail_reply_to.replace('{{{0}}}'.format(field['label']),
-                                                      field['value'])
+                                                      str(field['value']))
 
             mail_subject = mail_subject.replace('{{{0}}}'.format(field['label']),
-                                                field['value'])
+                                                str(field['value']))
 
         if mail_reply_to:
             mail_reply_to = (mail_reply_to,)


### PR DESCRIPTION
Forms with checkboxes will error because `field['value']` will be a `bool`.