### PR TITLE
Remove unnecessary parentheses that's causing a syntax error

### DIFF
--- a/djangocms_forms/static/js/djangocms_forms/jquery.djangocms-forms.js
+++ b/djangocms_forms/static/js/djangocms_forms/jquery.djangocms-forms.js
@@ -46,7 +46,7 @@
                 $(this).ajaxSubmit(ajaxOptions);
             });
 
-            if (typeof(grecaptcha) == 'undefined') || typeof(grecaptcha.render) =='undefined') {
+            if (typeof(grecaptcha) == 'undefined' || typeof(grecaptcha.render) =='undefined') {
                 window.reCapctchaOnloadCallback = function() {
                     this.renderReCaptcha();
                 }.bind(this);


### PR DESCRIPTION
Currently getting this set of javascript errors from the page when using a recaptcha because of a rogue parenthesis.

<img width="1440" alt="Screenshot 2019-03-11 12 49 50" src="https://user-images.githubusercontent.com/1429211/54141701-8f821f80-43fc-11e9-870e-411b45859486.png">
